### PR TITLE
add and demonstrate wildcards in tsconfig paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,19 @@
 {
   "name": "architect-typescript-example",
   "scripts": {
+    "lint": "eslint ./src --fix",
     "start": "arc sandbox"
   },
   "dependencies": {
-    "@architect/plugin-typescript": "^0.1.0",
     "whatev": "^1.0.0"
   },
   "devDependencies": {
-    "@architect/architect": "^10.0.3",
+    "@architect/architect": "^10.2.2",
     "@architect/eslint-config": "^2.0.1",
+    "@architect/plugin-typescript": "^0.1.0",
     "@types/aws-lambda": "^8.10.93",
-    "@types/node": "^17.0.21",
-    "eslint": "^8.10.0"
+    "@types/node": "^17.0.23",
+    "eslint": "^8.13.0"
   },
   "eslintConfig": {
     "extends": "@architect/eslint-config"

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,6 @@ Watch Architect TypeScript's built-in sourcemap support work by throwing within 
 
 Architect's built-in shared code folders (`src/shared` + `src/views`) work as expected with the plain JS handler.
 
-The TypeScript handler uses its own unique shared backend code folder (`src/shared-ts`, totally arbitrary), while still making use of shared code in `src/views` (by way of `tsconfig.json` `paths` setting).
+The TypeScript handler uses its own unique shared backend code folder (`src/shared-ts`, totally arbitrary), while still making use of shared code in `src/views` and `src/shared` (by way of `tsconfig.json` > `compilerOptions` > `paths` setting).
 
 > Note: you do not have to follow these shared code conventions for your project. Whatever works for you is fine! This app just demonstrates one approach that happens to interface with Architect's built-in shared code functionality.

--- a/src/http/get-index/index.ts
+++ b/src/http/get-index/index.ts
@@ -1,7 +1,27 @@
-import { Handler, APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda'
-type LambdaHandler = Handler<APIGatewayProxyEventV2, APIGatewayProxyResultV2>
-import msg from './message'
+import { Handler, APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+type LambdaHandler = Handler<APIGatewayProxyEventV2, APIGatewayProxyResultV2>;
 
-export const handler: LambdaHandler = async (event, context) => {
-  return { body: msg() }
+// a local import
+import msg from './message';
+
+// Imported code and corresponding `tsconfig.json` > `compilerOptions` > `paths` setting
+import tsShared from 'shared';                    // "shared": [ "src/shared-ts" ]
+import { createFizzBuzz } from 'shared/fizzBuzz'; // "shared/*": [ "src/shared-ts/*" ]
+import arcViews from '@architect/views';          // "@architect/views": [ "src/views" ]
+import arcShared from '@architect/shared';        // paths: "@architect/shared": [ "src/shared" ]
+
+const RANDOM = Math.floor(Math.random() * 30) + 1;
+
+export const handler: LambdaHandler = async (_event, _context) => {
+  return {
+    'statusCode': 200,
+    'headers': { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      msg: msg(),
+      'shared': tsShared(),
+      '@architect/views': arcViews(),
+      '@architect/shared': arcShared(),
+      'shared/fizzBuzz': `RANDOM=${RANDOM}: ${createFizzBuzz(RANDOM)}`,
+    }),
+  }
 }

--- a/src/http/get-index/message/index.ts
+++ b/src/http/get-index/message/index.ts
@@ -1,11 +1,6 @@
-import whatev from 'whatev'
-import copy from './copy'
-import shared from 'shared'
-
-// You don't need to use the @architect/[shared|views] pattern, since it'll all be bundled
-// But if you do want, see `tsconfig.json` for the `compilerOptions` settings
-import views from '@architect/views'
+import whatev from 'whatev';
+import copy from './copy';
 
 export default function (): string {
-  return `${copy()}; ${shared()}; ${views()}; and here's a string from a npm dep: ${whatev.string}!`
+  return `${copy()}; and here's a string from a npm dep: ${whatev.string}!`;
 }

--- a/src/shared-ts/fizzBuzz.ts
+++ b/src/shared-ts/fizzBuzz.ts
@@ -1,0 +1,13 @@
+function fizzBuzz (n: number): string {
+  if (n % 15 === 0) return 'FizzBuzz';
+  if (n % 3 === 0) return 'Fizz';
+  if (n % 5 === 0) return 'Buzz';
+  return String(n);
+}
+
+function createFizzBuzz (n: number): string {
+  const collected = Array(n + 1).fill(0).map((_, i) => fizzBuzz(i));
+  return collected.join(' 🐝 ');
+}
+
+export { createFizzBuzz };

--- a/src/shared-ts/index.ts
+++ b/src/shared-ts/index.ts
@@ -1,3 +1,3 @@
-module.exports = function (): string {
-  return `this bit of text was exported from custom TS shared`
+export default function (): string {
+  return `this bit of text was exported from custom TS shared`;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,12 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@architect/views": [ "src/views" ],
-      "shared": [ "src/shared-ts" ]
+      "shared/*": [ "src/shared-ts/*" ],
+      "shared": [ "src/shared-ts" ],
+      "@architect/shared/*": [ "src/shared/*" ],
+      "@architect/shared": [ "src/shared" ],
+      "@architect/views/*": [ "src/views/*" ],
+      "@architect/views": [ "src/views" ]
     }
   }
 }


### PR DESCRIPTION
I recently found that the example tsConfig works well if your module filenames are index.ts (and there is only one per path). But I wanted to import named files, so this PR expands the config to

```json
{
  "compilerOptions": {
    "baseUrl": ".",
    "paths": {
      "shared/*": [ "src/shared-ts/*" ],
      "shared": [ "src/shared-ts" ],
      "@architect/shared/*": [ "src/shared/*" ],
      "@architect/shared": [ "src/shared" ],
      "@architect/views/*": [ "src/views/*" ],
      "@architect/views": [ "src/views" ]
    }
  }
}
```

I also changed the get-index handler to return a more verbose object/dictionary to demonstrate the different paths. This involved being really specific about response details in order to keep types from `aws-lambda` happy

Also, fizzbuzz :bee: